### PR TITLE
Fix double evaluation in CHK_H5 macro.

### DIFF
--- a/inc/ASDF_common.h
+++ b/inc/ASDF_common.h
@@ -22,6 +22,11 @@
 #ifndef _ASDF_COMMON_H_
 #define _ASDF_COMMON_H_
 
-#define CHK_H5(X) if ((X) < 0) return X;
+#define CHK_H5(X) \
+    do { \
+        int ret__ = (X); \
+        if (ret__ < 0) \
+            return ret__; \
+    } while (0)
 
 #endif


### PR DESCRIPTION
In the case that the call failed, this macro would perform the call again when returning the result. There is no reason why this second call would produce the same error, thus causing subtle masking of problems.

This is a common cause of bugs when writing macros.
