### PR TITLE
build: Add install targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required (VERSION 2.8)
 ############################################################
 project (ASDF)
 
+include(GNUInstallDirs)
+
 find_package(HDF5 1.8.0 REQUIRED)
 include_directories(${HDF5_INCLUDE_DIR})
 find_package(MPI REQUIRED)
@@ -30,6 +32,13 @@ add_library (asdf
 
 target_link_libraries(asdf ${HDF5_LIBRARIES} ${MPI_C_LIBRARIES})
 
+install(TARGETS asdf
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+file(GLOB inc_files inc/*.h)
+install(FILES ${inc_files}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
 ############################################################
 ### Documentation Generation                             ###
 ############################################################
@@ -54,8 +63,13 @@ if (BUILD_DOCUMENTATION)
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       COMMENT "Generating API documentation with Doxygen"
       VERBATIM)
+
+  install(DIRECTORY ${CMAKE_BINARY_DIR}/doc/html
+          DESTINATION ${CMAKE_INSTALL_DOCDIR})
 endif()
 
+install(FILES README.md
+        DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 ############################################################
 if (TEST)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ make
 Finding the correct MPI / HDF5 libraries does not seem to be working all the 
 same on different systems.
 
-If the compilation complains about a missing ```use mpi```, try the following:
+If the compilation complains about a missing ``use mpi``, try the following:
 
 ```bash
 $ cmake . -DCMAKE_Fortran_COMPILER=mpif90
@@ -27,14 +27,14 @@ $ cmake . -DCMAKE_Fortran_COMPILER=h5pfc
 $ make 
 ```
 
-It should create a library in ```lib/``
-examples programs are in test/ and generated there.
+It should create a library in ``lib/``
+examples programs are in ``test/`` and generated there.
 
 If documentation needs to be generated:
 ```
 cmake -DBUILD_DOCUMENTATION=ON
 ```
-You should have doxygen installed. Documentation will be generated in ```doc/```.
+You should have doxygen installed. Documentation will be generated in ``doc/``.
 
 For out-of source builds, start with:
 ```bash
@@ -42,7 +42,7 @@ $ mkdir build/
 $ cd build/
 ```
 
-and follow the previous instructions, replacing ```.``` with ```..```
+and follow the previous instructions, replacing ``.`` with ``..``
 
 Once build, you may run test with:
 ```bash

--- a/README.md
+++ b/README.md
@@ -48,3 +48,22 @@ Once build, you may run test with:
 ```bash
 $ make test
 ```
+
+To install in a nonstandard location (e.g., a user directory without root
+privileges), you can either set ``CMAKE_INSTALL_PREFIX`` during configuration
+or ``DESTDIR`` during install, e.g.,
+
+```bash
+$ cmake -DCMAKE_INSTALL_PREFIX=/path/to/toplevel/install/directory <options> .
+$ make
+$ make install
+```
+or
+```bash
+$ cmake <options> .
+$ make
+$ make DESTDIR=/path/to/toplevel/install/directory install
+```
+
+Note that the files end up in ``$DESTDIR/$CMAKE_INSTALL_PREFIX/*``, so it is
+only necessary to set one of these.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,3 +36,6 @@ target_link_libraries(read_example_f90
                       ${MPI_Fortran_LINK_FLAGS}
                       ${MPI_LIBRARIES}
                       ${MPI_Fortran_LIBRARIES})
+
+install(FILES write_ASDF.c write_example.f90 read_example.f90
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}/examples/)


### PR DESCRIPTION
This allows standard installation using `make install`. The default is the usual split like:
- `/usr/local/include/ASDF*.h`
- `/usr/local/lib64/libasdf.so` (or `lib` and/or `libasdf.a`)
- `/usr/local/share/doc/ASDF/README.md` + `html` if enabled

These locations can be overridden by setting the relevant `$CMAKE_INSTALL_*` settings when running `cmake`, but most people don't need to mess with them as the defaults work most of the time.

The shared library is not yet correctly versioned; I assume we can add that when closer to a release.
