### PR TITLE
Make warnings into errors on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
         -DTEST=ON
         -DBUILD_SHARED_LIBS=$SHARED
         -DCMAKE_Fortran_COMPILER=mpif90
+        -DCMAKE_BUILD_TYPE=Debug
         ..
     - make
     - make doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,17 @@ project (ASDF)
 
 include(GNUInstallDirs)
 
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Werror")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Werror")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO
+    "${CMAKE_C_FLAGS_RELWITHDEBINFO} -Wall -Werror")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
+    "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -Wall -Werror")
+
+############################################################
+### Dependencies                                         ###
+############################################################
+
 find_package(HDF5 1.8.0 REQUIRED)
 include_directories(${HDF5_INCLUDE_DIR})
 find_package(MPI REQUIRED)
@@ -64,9 +75,9 @@ else()
   CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
   CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
   if (COMPILER_SUPPORTS_CXX11)
-    SET(CMAKE_CXX_FLAGS "-std=c++11")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
   elseif (COMPILER_SUPPORTS_CXX0X)
-    SET(CMAKE_CXX_FLAGS "-std=c++0x")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
   else()
     message(FATAL_ERROR
             "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. "

--- a/inc/ASDF_read.h
+++ b/inc/ASDF_read.h
@@ -144,6 +144,18 @@ int ASDF_exists_in_path(hid_t file_id, const char *path, const char *name);
  */
 int ASDF_station_exists(hid_t file_id, const char *name);
 
+/**
+ * @brief Check if an adjoint source called \p name exists in file \p file_id
+ *
+ * @param file_id The identifier of the file to look in
+ * @param name The adjoint source name being checked.
+ *
+ * @return
+ *
+ * @note It is looking for a variable `"/AuxiliaryData/AdjointSource/<name>"`
+ */
+int ASDF_adjoint_source_exists(hid_t file_id, const char *name);
+
 /** 
  * @brief Check if a waveform \p waveform_name is present for station
  *        \p station_name in file \p file_id

--- a/src/ASDF_provenance.c
+++ b/src/ASDF_provenance.c
@@ -20,6 +20,8 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "ASDF_provenance.h"
 #include "gen_sf_parfile_provenance.h"

--- a/src/ASDF_read.c
+++ b/src/ASDF_read.c
@@ -63,14 +63,7 @@ int ASDF_read_str_attr(hid_t file_id, const char *grp_name,
 }
 
 int ASDF_get_num_elements_dataset(hid_t dataset_id) {
-    hsize_t memsize;
     hid_t dspace;
-    hid_t dataset_type;
-    size_t type_size;
-
-    // CHK_H5(memsize = H5Dget_storage_size(dataset_id));
-    // CHK_H5(dataset_type = H5Dget_type(dataset_id));
-    // CHK_H5(type_size = H5Tget_size(dataset_type));
 
     dspace = H5Dget_space(dataset_id);
 
@@ -83,8 +76,6 @@ int ASDF_get_num_elements_dataset(hid_t dataset_id) {
 
     // returns the size of the first dimension
     return (int) dims[0];
-
-    //return (int) memsize / type_size;
 }
 
 int ASDF_get_num_elements_from_path(hid_t file_id, const char *path) {

--- a/src/ASDF_write.c
+++ b/src/ASDF_write.c
@@ -243,7 +243,7 @@ hid_t ASDF_define_waveform(hid_t loc_id, int nsamples,
   char char_start_time[10];
 
   // converts to decimal base.
-  snprintf(char_start_time, sizeof(char_start_time), "%d", start_time);
+  snprintf(char_start_time, sizeof(char_start_time), "%lld", start_time);
   snprintf(char_sampling_rate,
            sizeof(char_sampling_rate), "%1.7f", sampling_rate);
 
@@ -279,7 +279,7 @@ herr_t ASDF_define_waveforms(hid_t loc_id, int num_waveforms, int nsamples,
   char char_start_time[10];
 
   // converts to decimal base.
-  snprintf(char_start_time, sizeof(char_start_time), "%d", start_time);
+  snprintf(char_start_time, sizeof(char_start_time), "%lld", start_time);
   snprintf(char_sampling_rate,
            sizeof(char_sampling_rate), "%1.7f", sampling_rate);
 


### PR DESCRIPTION
Too many warnings are slipping through and they indicate real issues that should be fixed. I did not enable the extra warnings (`-Wextra`) but maybe that should be done too.
